### PR TITLE
Center initial view of CircularSubset

### DIFF
--- a/Data/main.js
+++ b/Data/main.js
@@ -98,7 +98,7 @@ function main()
 			map.mapTypes.set(layer.id, minecraftMapType);
 			
 			// Set the starting lat-long pos
-			var startPoint = minecraftMapType.projection.worldToMap(tecMap.worldVectors.spawnPosition);
+			var startPoint = minecraftMapType.projection.worldToMap(tecMap.worldVectors.startView);
 			var startLatLong = minecraftMapType.projection.fromPointToLatLng(startPoint);
 			tecMap.viewLatLong = startLatLong; // 'viewLatLong' stores view pos for a given map, so we don't end up looking at nothing when we toggle between terra and nether
 		}
@@ -117,9 +117,9 @@ function main()
 	// Try and get a starting view from the fragment params, query params, or fall back to default
 	var startView;
 	if (size(fragmentParams) > 0)
-		startView = findStartView(fragmentParams, startLayer.id, startMap.worldVectors.spawnPosition);
+		startView = findStartView(fragmentParams, startLayer.id, startMap.worldVectors.startView);
 	else
-		startView = findStartView(queryParams, startLayer.id, startMap.worldVectors.spawnPosition);
+		startView = findStartView(queryParams, startLayer.id, startMap.worldVectors.startView);
 	
 	// Set the starting view
 	map.setMapTypeId(startView.layerId);

--- a/Source/tectonicus/TileRenderer.java
+++ b/Source/tectonicus/TileRenderer.java
@@ -301,7 +301,7 @@ public class TileRenderer
 			}
 			
 			// Output world vectors for this camera config
-			outputWorldVectors( new File(mapDir, "worldVectors.js"), map.getId(), worldVectors, bounds, world.getLevelDat(), worldStats.numChunks(), world.numPlayers());
+			outputWorldVectors( new File(mapDir, "worldVectors.js"), map.getId(), worldVectors, bounds, world.getLevelDat(), worldStats.numChunks(), world.numPlayers(), map);
 		}
 		
 		// Output html resources
@@ -1284,7 +1284,7 @@ public class TileRenderer
 		}
 	}
 	
-	private void outputWorldVectors(File vectorsFile, String varNamePrefix, WorldVectors worldVectors, TileCoordBounds bounds, LevelDat levelDat, final int numChunks, final int numPlayers)
+	private void outputWorldVectors(File vectorsFile, String varNamePrefix, WorldVectors worldVectors, TileCoordBounds bounds, LevelDat levelDat, final int numChunks, final int numPlayers, tectonicus.configuration.Map map)
 	{
 		if (vectorsFile.exists())
 			vectorsFile.delete();
@@ -1296,6 +1296,7 @@ public class TileRenderer
 		final int surfaceAreaM = numChunks * RawChunk.WIDTH * RawChunk.DEPTH;
 		final DecimalFormat formatter = new DecimalFormat("####.#");
 		final String surfaceArea = formatter.format(surfaceAreaM / 1000.0f / 1000.0f);
+		
 		
 		JsonWriter json = null;
 		try
@@ -1314,6 +1315,35 @@ public class TileRenderer
 			// Spawn point
 			json.writeWorldCoord("spawnPosition", levelDat.getSpawnPosition());
 			
+			// Start view
+			
+			Vector3l startView = new Vector3l();
+			
+			if (map.getWorldSubsetFactory().getClass() == CircularWorldSubsetFactory.class)
+			{
+				CircularWorldSubsetFactory subset = (CircularWorldSubsetFactory) map.getWorldSubsetFactory();
+
+				
+				if(subset.getOrigin() != null)
+				{
+					startView.x = subset.getOrigin().x;
+					startView.y = 64;  //sealevel
+					startView.z = subset.getOrigin().z;
+				}
+				else
+				{
+					startView.x = 0;
+					startView.y = 64;  //sealevel
+					startView.z = 0;
+				}
+			}
+			else
+			{
+				startView=levelDat.getSpawnPosition();
+			}
+			
+			json.writeWorldCoord("startView", startView);
+						
 			Vector2f origin = new Vector2f();
 			origin.x = (worldVectors.origin.x / scale);
 			origin.y = (worldVectors.origin.y / scale);

--- a/TectonicusBuild.xml
+++ b/TectonicusBuild.xml
@@ -4,7 +4,7 @@
 	
 	<property name="ProjectName" 		value="Tectonicus" />
 	
-	<property name="Version"			value="2.RV" />
+	<property name="Version"			value="2.RV.2016-04-26" />
 	
 	<property name="Source"				location="Source" />
 	<property name="Data"				location="Data" />


### PR DESCRIPTION
When a CircularSubset is used, the initial view is now points to the center of the subset instead the spawn position.
This helps if the subset is far away from the spawn position.

Related issue:
https://github.com/tectonicus/tectonicus/issues/69
